### PR TITLE
fix: correct date formatting, deprecated options, and seeder compatibility

### DIFF
--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -2,9 +2,7 @@ const mongoose = require('mongoose');
 
 mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/deep-thoughts', {
   useNewUrlParser: true,
-  useUnifiedTopology: true,
-  useCreateIndex: true,
-  useFindAndModify: false
+  useUnifiedTopology: true
 });
 
 module.exports = mongoose.connection;

--- a/server/seeders/seeds.js
+++ b/server/seeders/seeds.js
@@ -18,18 +18,19 @@ db.once('open', async () => {
     userData.push({ username, email, password });
   }
 
-  const createdUsers = await User.collection.insertMany(userData);
+  const { insertedIds } = await User.collection.insertMany(userData);
+  const usersWithIds = userData.map((user, i) => ({ ...user, _id: insertedIds[i] }));
 
   // create friends
   for (let i = 0; i < 100; i += 1) {
-    const randomUserIndex = Math.floor(Math.random() * createdUsers.ops.length);
-    const { _id: userId } = createdUsers.ops[randomUserIndex];
+    const randomUserIndex = Math.floor(Math.random() * usersWithIds.length);
+    const { _id: userId } = usersWithIds[randomUserIndex];
 
     let friendId = userId;
 
     while (friendId === userId) {
-      const randomUserIndex = Math.floor(Math.random() * createdUsers.ops.length);
-      friendId = createdUsers.ops[randomUserIndex];
+      const randomUserIndex = Math.floor(Math.random() * usersWithIds.length);
+      friendId = usersWithIds[randomUserIndex];
     }
 
     await User.updateOne({ _id: userId }, { $addToSet: { friends: friendId } });
@@ -40,8 +41,8 @@ db.once('open', async () => {
   for (let i = 0; i < 100; i += 1) {
     const thoughtText = faker.lorem.words(Math.round(Math.random() * 20) + 1);
 
-    const randomUserIndex = Math.floor(Math.random() * createdUsers.ops.length);
-    const { username, _id: userId } = createdUsers.ops[randomUserIndex];
+    const randomUserIndex = Math.floor(Math.random() * usersWithIds.length);
+    const { username, _id: userId } = usersWithIds[randomUserIndex];
 
     const createdThought = await Thought.create({ thoughtText, username });
 
@@ -57,8 +58,8 @@ db.once('open', async () => {
   for (let i = 0; i < 100; i += 1) {
     const reactionBody = faker.lorem.words(Math.round(Math.random() * 20) + 1);
 
-    const randomUserIndex = Math.floor(Math.random() * createdUsers.ops.length);
-    const { username } = createdUsers.ops[randomUserIndex];
+    const randomUserIndex = Math.floor(Math.random() * usersWithIds.length);
+    const { username } = usersWithIds[randomUserIndex];
 
     const randomThoughtIndex = Math.floor(Math.random() * createdThoughts.length);
     const { _id: thoughtId } = createdThoughts[randomThoughtIndex];

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-const secret = 'mysecretsshhhhh';
+const secret = process.env.JWT_SECRET || 'mysecretsshhhhh';
 const expiration = '2h';
 
 module.exports = {

--- a/server/utils/dateFormat.js
+++ b/server/utils/dateFormat.js
@@ -46,15 +46,7 @@ module.exports = (
     : dateObj.getDate();
 
   const year = dateObj.getFullYear();
-  let hour =
-    dateObj.getHours() > 12
-      ? Math.floor(dateObj.getHours() / 2)
-      : dateObj.getHours();
-
-  // if hour is 0 (12:00am), change it to 12
-  if (hour === 0) {
-    hour = 12;
-  }
+  const hour = dateObj.getHours() % 12 || 12;
 
   const minutes = dateObj.getMinutes();
 


### PR DESCRIPTION
## Summary
- Fix hours calculation bug in `dateFormat.js` (`% 12 || 12` instead of `/ 2`)
- Remove deprecated Mongoose connection options (`useCreateIndex`, `useFindAndModify`)
- Read JWT secret from `JWT_SECRET` env variable with dev fallback
- Replace removed `createdUsers.ops` API with `insertedIds` mapping in `seeds.js`

## Test plan
- [ ] Verify timestamps display correct 12-hour time (e.g. 3:00pm not 7:00pm)
- [ ] Confirm no Mongoose deprecation warnings on server startup
- [ ] Run `npm run seed` and confirm seeding completes without errors
- [ ] Set `JWT_SECRET` env var and confirm auth still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)